### PR TITLE
Add popup notice directing visitors to new site and remove unused link

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -590,3 +590,69 @@ h5 {
     text-align: left;
   }
 }
+
+/* Popup Notification */
+.popup-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.popup-content {
+  background-color: white;
+  padding: 2rem;
+  border-radius: 8px;
+  max-width: 90%;
+  width: 500px;
+  text-align: center;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.popup-content p {
+  margin-bottom: 1.5rem;
+  font-size: 1.1rem;
+  line-height: 1.5;
+}
+
+.popup-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.visit-btn {
+  background-color: #ec1f27;
+  color: white;
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: bold;
+  transition: background-color 0.2s;
+}
+
+.visit-btn:hover {
+  background-color: #d41b23;
+  text-decoration: none;
+}
+
+.dismiss-btn {
+  background-color: #f0f0f0;
+  color: #333;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: background-color 0.2s;
+}
+
+.dismiss-btn:hover {
+  background-color: #e0e0e0;
+}

--- a/assets/js/mapbox.js
+++ b/assets/js/mapbox.js
@@ -36,7 +36,7 @@ legendSizes.innerHTML =
 // Add attribution control
 var attributionControl = new mapboxgl.AttributionControl({
   customAttribution:
-    "<a href='mailto:tenantscdsa@gmail.com' target='_blank' rel='noopener'><b>Improve our data</b></a> | <a href='https://github.com/ChicagoDSA/find-my-landlord' target='_blank' rel='noopener'>View on Github</a>",
+    "<a href='https://github.com/ChicagoDSA/find-my-landlord' target='_blank' rel='noopener'>View on Github</a>",
 });
 map.addControl(attributionControl);
 

--- a/assets/js/popup.js
+++ b/assets/js/popup.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const popup = document.getElementById('update-notification');
+    const dismissBtn = document.querySelector('.dismiss-btn');
+    
+    // Show popup when page loads
+    popup.style.display = 'flex';
+    
+    // Handle dismiss button click
+    dismissBtn.addEventListener('click', function() {
+        popup.style.display = 'none';
+    });
+});
+
+window.onload = function() {
+  document.getElementById('redirectPopup').style.display = 'flex';
+}; 

--- a/index.html
+++ b/index.html
@@ -31,6 +31,13 @@
 	</head>
 
 	<body>
+		<div id="redirectPopup" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background-color:rgba(0,0,0,0.85); color:#000000; display:flex; align-items:center; justify-content:center; z-index:10000;">
+			<div style="max-width:400px; text-align:center; padding:20px; background:#ffffff; border-radius:8px;">
+				<h2>Notice:</h2>
+				<p>Find My Landlord is no longer actively updated, but similar information is available for Chicago at Landlord Mapper</p>
+				<a href="https://landlordmapper.org/chi" style="display:inline-block; margin:15px 0; padding:12px 24px; background:#ec1f27; color:#fff; text-decoration:none; border-radius:5px; font-size:16px;">Visit New Site</a>
+			</div>
+		</div>
 		<div id="map"></div>
 
 		<div id="spinner">
@@ -142,5 +149,7 @@
 		<script src="assets/js/createPDF.js"></script>
 		<!-- About box -->
 		<script src="assets/js/about.js"></script>
+		<!-- Popup notification -->
+		<script src="assets/js/popup.js"></script>
 	</body>
 </html>      


### PR DESCRIPTION
This PR adds a popup notice to inform visitors that Find My Landlord is no longer actively updated and directs them to the newer, actively maintained Landlord Mapper tool.

Added assets/js/popup.js for popup logic

Updated index.html to include the popup markup

Modified assets/css/style.css for popup styling

Removed the "improve our data" link which is no longer relevant

Designed for clear, accessible UX with a single high-contrast call to action and no dismiss button, per conversation with project admin.